### PR TITLE
Remove duplicate line

### DIFF
--- a/cmd/crowdsec-cli/config_show.go
+++ b/cmd/crowdsec-cli/config_show.go
@@ -58,7 +58,6 @@ var configShowTemplate = `Global:
 
 {{- if .ConfigPaths }}
    - Configuration Folder   : {{.ConfigPaths.ConfigDir}}
-   - Configuration Folder   : {{.ConfigPaths.ConfigDir}}
    - Data Folder            : {{.ConfigPaths.DataDir}}
    - Hub Folder             : {{.ConfigPaths.HubDir}}
    - Simulation File        : {{.ConfigPaths.SimulationFilePath}}


### PR DESCRIPTION
Remove duplicate line (60) which is outputting `Configuration Folder` twice in `cscli config show`